### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities list
- Description highlights it's part of the GitHub Certifications program
- Scheduled for Wednesdays, 3:30 PM - 5:00 PM
- Set capacity to 25 students
- Ready for student registration

## Fixes
Closes #6

## Details
This is time-sensitive as the principal announced that registration closes by the end of this week. Students can now sign up for this activity which will help with their college applications through the GitHub Certifications program.